### PR TITLE
Adds typescript-styled-plugin to compiler options as plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "workbench.colorCustomizations": {
+    "titleBar.activeForeground": "#29323F",
+    "titleBar.inactiveForeground": "#29323F",
+    "titleBar.activeBackground": "#8CCBDF",
+    "titleBar.inactiveBackground": "#8CCBDF"
+  },
+  "editor.formatOnSave": true,
+  "editor.rulers": [100]
+}

--- a/devDependencies.json
+++ b/devDependencies.json
@@ -17,5 +17,6 @@
   "tslint": "^5.11.0",
   "tslint-config-prettier": "^1.15.0",
   "tslint-react": "^3.6.0",
-  "typescript": "^3.1.3"
+  "typescript": "^3.1.3",
+  "typescript-styled-plugin": "^0.12.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,12 @@
     "sourceMap": true,
     "noImplicitReturns": true,
     "noImplicitAny": false,
-    "lib": ["es7"]
+    "lib": ["es7"],
+    "plugins": [
+      {
+        "name": "typescript-styled-plugin"
+      }
+    ]
   },
   "exclude": ["node_modules"],
   "include": ["src", "test", "storybook"],


### PR DESCRIPTION
This PR adds [typescript-styled-plugin](https://github.com/Microsoft/typescript-styled-plugin) as a dependency to a project in order to get intellisense for styled components.

## Changes

- Adds typescript-styled-plugin as a dev dependency
- Configures typescript-styled-plugin as a compiler option plugin
- Adds vscode settings with echobind specific styling

## Checklist

- [x] Checked installation

Fixes #5 