### PR TITLE
Fix default props for component SFC template

### DIFF
--- a/_templates/component/new/component.ejs
+++ b/_templates/component/new/component.ejs
@@ -54,14 +54,22 @@ interface Props {
   style: ViewStyle;
 }
 
+const DEFAULT_PROPS: Props = {
+  cool: true,
+  style: {},
+}
+
 /**
  * Component docs: what does this component do?
  */
-export const <%= comp %>: SFC<Props> = ({ cool = true, children }) => (
-  <View {...props}>
-    {children}
-  </View>
-);
+export const <%= comp %>: SFC<Props> = (props = DEFAULT_PROPS) => {
+  const { children, ...viewProps } = props;
+  return (
+    <View {...viewProps}>
+      {children}
+    </View>
+  );
+};
 <% } -%>
 
 export default <%= comp %>;


### PR DESCRIPTION
## Changes
- Defines default props to be used with an SFC component
- Destructures children from view props

## Screenshots
(prefer animated gif)

## Checklist
- [x] Checks installation
- [x] Checks `yarn g:component ComponentName` w/ SFC option selected

Fixes #8 
