### PR TITLE
Remove .babelrc file

### DIFF
--- a/setup/index.js
+++ b/setup/index.js
@@ -27,6 +27,7 @@ execSync('bundle exec fastlane ios icon', { cwd: bundleDirectory });
 execSync('bundle exec fastlane android icon', { cwd: bundleDirectory });
 
 console.log('\n🗑  Removing cruft...');
+deleteFile('../.babelrc'); // metro bundler version uses babel.config.js
 deleteFile('../.flowconfig');
 deleteFile('jest.json');
 deleteFile('detox.json');


### PR DESCRIPTION
Overview / Description
Delete `.babelrc` file upon repository setup, to allow `babel.config.js` to be resolved by metro bundler

## Changes
- Delete file when running `node ./setup` script.

## Screenshots
(prefer animated gif)

## Checklist
- [ ] Automated tests
- [x] Checked on iOS
- [x] Checked on Android
