### PR TITLE
Fix Jest Setup w/ TS

### DIFF
--- a/setup/jest.json
+++ b/setup/jest.json
@@ -1,8 +1,15 @@
 {
   "preset": "react-native",
   "moduleFileExtensions": ["ts", "tsx", "js"],
+  "globals": {
+    "ts-jest": {
+      "tsConfig": {
+        "isolatedModules": false
+      }
+    }
+  },
   "transform": {
-    "^.+\\.(js)$": "<rootDir>/node_modules/babel-jest",
+    "^.+\\.(js)$": "<rootDir>/node_modules/react-native/jest/preprocessor.js",
     "\\.(ts|tsx)$": "ts-jest"
   },
   "testRegex": "(/__tests__/.*|(test|spec))\\.(ts|tsx|js)$",


### PR DESCRIPTION
Overview / Description
Jest setup was incorrect for newer react-native version requiring newer language feature proposals.
Using included transform for jest inside react-native resolved JS transform issue.

## Changes
- Switch `.js` transform config to use `react-native`'s `jest` pre-processor.
- Disable Typescript `isolatedModules` for tests since tests usually have an export.

## Screenshots
![screenshot 2018-12-17 16 47 16](https://user-images.githubusercontent.com/7504299/50124990-c8ef2880-021b-11e9-9093-ed65801b422c.png)

## Checklist
- [ ] Automated tests
- [ ] Checked on iOS
- [ ] Checked on Android

Fixes #21 
