### PR TITLE
chore(workflow): remove stray `.gitattributes`, add .jest to gitnore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.pbxproj -text

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ fastlane/screenshots
 
 # Bundle artifact
 *.jsbundle
+
+# misc
+.jest


### PR DESCRIPTION
Looks like a `.gitattributes` file was checked in. That was causing git to get really confused.
This also ignores `.jest` as I doubt we'll need anything there

## Changes
- Remove .gitattributes
- add .jest to .gitignore

## Screenshots
n/a

## Checklist
- [ ] Automated tests
- [ ] Checked on iOS
- [ ] Checked on Android

Fixes #2
