### PR TITLE
chore(workflow): automatically run git commit after setup

### DIFF
--- a/setup/index.js
+++ b/setup/index.js
@@ -21,10 +21,10 @@ console.log('\n📝  Writing package.json...');
 writeFile('../package.json', JSON.stringify(packageJson, null, 2));
 
 console.log('\n🛠  Setting up fastlane and installing app icons...');
-const bundleDirectory = path.join(__dirname, '../');
-execSync('bundle install', { cwd: bundleDirectory });
-execSync('bundle exec fastlane ios icon', { cwd: bundleDirectory });
-execSync('bundle exec fastlane android icon', { cwd: bundleDirectory });
+const rootDirectory = path.join(__dirname, '../');
+execSync('bundle install', { cwd: rootDirectory });
+execSync('bundle exec fastlane ios icon', { cwd: rootDirectory });
+execSync('bundle exec fastlane android icon', { cwd: rootDirectory });
 
 console.log('\n🗑  Removing cruft...');
 deleteFile('../.babelrc'); // metro bundler version uses babel.config.js
@@ -39,7 +39,9 @@ deleteFile('../App.js');
 deleteDirectory('.');
 
 console.log('\n📝 Committing project...');
-execSync('git add . && git commit -m "Initialize new React Native project."');
+execSync('git add . && git commit -m "Initialize new React Native project."', {
+  cwd: rootDirectory,
+});
 
 console.log(`\n✅  Setup completed!`);
 

--- a/setup/index.js
+++ b/setup/index.js
@@ -38,6 +38,9 @@ deleteFile('index.js');
 deleteFile('../App.js');
 deleteDirectory('.');
 
+console.log('\n📝 Committing project...');
+execSync('git add . && git commit -m "Initialize new React Native project."');
+
 console.log(`\n✅  Setup completed!`);
 
 console.log('\n\n------------------------');


### PR DESCRIPTION
This commits the code to git immediately after running `setup`. Users are expected to add the rmote, but this ensures that additional setup tasks don't become part of the initial app generation commit.

## Changes
- run `git add .. && git commit -m "Initialize new React Native project."` as the current user.

## Screenshots
n/a

## Checklist
- [ ] Automated tests
- [ ] Checked on iOS
- [ ] Checked on Android

Fixes #4 
