### PR TITLE
fix(workflow): correctly use JSDoc comments in templates

### DIFF
--- a/_templates/component/new/component.ejs
+++ b/_templates/component/new/component.ejs
@@ -9,14 +9,14 @@ import { View, ViewStyle } from 'react-native';
 import { colors } from '../../styles';
 
 interface Props {
-  /** prop info **/
+  /** prop info */
   cool: boolean;
-  /** prop info **/
+  /** prop info */
   style: ViewStyle;
 }
 
 interface State {
-  /** state info **/
+  /** state info */
   myStateValue?: boolean;
 }
 
@@ -48,9 +48,9 @@ import React, { SFC } from "react";
 import { View, ViewStyle } from 'react-native';
 
 interface Props {
-  /** prop info **/
+  /** prop info */
   cool: boolean;
-  /** prop info **/
+  /** prop info */
   style: ViewStyle;
 }
 

--- a/_templates/screen/new/component.ejs
+++ b/_templates/screen/new/component.ejs
@@ -9,10 +9,12 @@ import { Screen } from '../../components/Screen';
 import { Text } from '../../components/Text';
 
 interface Props {
+  /** prop info */
   myProp: string;
 }
 
 interface State {
+  /** state info */
   myStateValue?: boolean;
 }
 
@@ -42,6 +44,7 @@ import { View } from 'react-native';
 import { Screen } from '../../components/Screen';
 
 interface Props {
+  /** prop info */
   myProp: string;
 }
 


### PR DESCRIPTION
This changes the JSDoc comments in component templates to have the correct format.

## Changes
- jsdoc should be `/** thing */` not `/** thing **/`

## Screenshots
n/a

## Checklist
- [ ] Automated tests
- [ ] Checked on iOS
- [ ] Checked on Android

Fixes #7 