### PR TITLE
fix(generators): don't use className in component story generator

### DIFF
--- a/_templates/component/new/stories.ejs
+++ b/_templates/component/new/stories.ejs
@@ -7,5 +7,5 @@ import React from "react";
 import { <%= comp %> } from "./component";
 
 storiesOf("components/<%= comp %>", module).add("Default", () => (
-  <<%= comp %>  className="myClass" />
+  <<%= comp %> />
 ));


### PR DESCRIPTION
Previously, our component story template had classNames in it. I double-checked the rest of the project and this looks like the only occurrence.

## Changes
- remove it

## Screenshots
n/a

## Checklist
- [ ] Automated tests
- [x] Creating a new project still works
~- [ ] Added docs~
- [x] PR title follows conventional changelog style. examples - "chore(dependencies): upgrade RN to 0.58", "fix(storybook) add missing stories for built-in components", "feat(workflow): auto-commit project after creating" 

Fixes #9 