### PR TITLE
fix(install): upgrade husky, move to new config, fix git init

### DIFF
--- a/husky.config.js
+++ b/husky.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {
+    'pre-commit': 'lint-staged',
+  },
+};

--- a/setup/index.js
+++ b/setup/index.js
@@ -29,17 +29,13 @@ execSync('bundle exec fastlane android icon', { cwd: rootDirectory });
 console.log('\n🗑  Removing cruft...');
 deleteFile('../.babelrc'); // metro bundler version uses babel.config.js
 deleteFile('../.flowconfig');
-deleteFile('jest.json');
-deleteFile('detox.json');
-deleteFile('lintStaged.json');
-deleteFile('rnpm.json');
-deleteFile('scripts.json');
-deleteFile('index.js');
 deleteFile('../App.js');
-deleteDirectory('.');
+deleteFile('../.gitattributes'); // not sure why this is here?
+execSync('rm -rf setup', { cwd: rootDirectory });
+execSync('rm -rf .git', { cwd: rootDirectory }); // blow away old repo if there
 
 console.log('\n📝 Committing project...');
-execSync('git add . && git commit -m "Initialize new React Native project."', {
+execSync('git init && git add . && git commit -m "Initialize new React Native project."', {
   cwd: rootDirectory,
 });
 

--- a/setup/scripts.json
+++ b/setup/scripts.json
@@ -4,7 +4,6 @@
   "test:e2e": "RN_SRC_EXT=e2e.js detox build --configuration ios.sim.debug && detox test --configuration ios.sim.debug",
   "test:e2e:ci": "RN_SRC_EXT=e2e.js detox build --configuration ios.sim.release && detox test --configuration ios.sim.release --cleanup",
   "lint": "tslint -p .",
-  "precommit": "lint-staged",
   "storybook": "storybook start -p 7007",
   "g:component": "hygen component new --name",
   "g:screen": "hygen screen new --name",


### PR DESCRIPTION
precommit hooks via husky are broken now, so we need to upgrade. this moves config to husky.config.js.

it also cleans up git init and removes the entire setup directory in one command (this will keep getting larger)

Overview / Description

## Changes
- migrate husky config to `husky.config.js`
- remove stray git references on setup
- remove entire setup directory when we're done with it vs individual files
- call `git init` 🤦‍♂️ 

## Screenshots
n/a

## Checklist
- [ ] Automated tests
- [x] Creating a new project still works
~- [ ] Added docs~
- [x] PR title follows conventional changelog style

Fixes #35
