### PR TITLE
 feat(auto-version): automate initial version for iOS + Android projects to allow fastlane versioning

### DIFF
--- a/setup/index.js
+++ b/setup/index.js
@@ -31,12 +31,19 @@ execSync('rm -rf ios/HelloWorld/Base.lproj/LaunchScreen.xib', { cwd: rootDirecto
 execSync('yarn hygen setup splashscreen');
 
 console.log('\n🗑  Removing cruft...');
-deleteFile('../.babelrc'); // metro bundler version uses babel.config.js
 deleteFile('../.flowconfig');
 deleteFile('../App.js');
 deleteFile('../.gitattributes'); // not sure why this is here?
 execSync('rm -rf setup', { cwd: rootDirectory });
 execSync('rm -rf .git', { cwd: rootDirectory }); // blow away old repo if there
+
+console.log('\n📱 Setting initial version @0.0.1 ...');
+execSync(
+  'yarn add -D react-native-version && ./node_modules/.bin/react-native-version  --never-increment-build && yarn remove react-native-version',
+  {
+    cwd: rootDirectory,
+  },
+);
 
 console.log('\n📝 Committing project...');
 execSync(

--- a/setup/index.js
+++ b/setup/index.js
@@ -37,6 +37,14 @@ deleteFile('../.gitattributes'); // not sure why this is here?
 execSync('rm -rf setup', { cwd: rootDirectory });
 execSync('rm -rf .git', { cwd: rootDirectory }); // blow away old repo if there
 
+console.log('\n📱 Setting initial version @0.0.1 ...');
+execSync(
+  'yarn add -D react-native-version && ./node_modules/.bin/react-native-version  --never-increment-build && yarn remove react-native-version',
+  {
+    cwd: rootDirectory,
+  },
+);
+
 console.log('\n📝 Committing project...');
 execSync(
   'rm -rf .git && git init && git add . && git commit -m "Initialize new React Native project."',

--- a/setup/index.js
+++ b/setup/index.js
@@ -38,12 +38,9 @@ execSync('rm -rf setup', { cwd: rootDirectory });
 execSync('rm -rf .git', { cwd: rootDirectory }); // blow away old repo if there
 
 console.log('\n📱 Setting initial version @0.0.1 ...');
-execSync(
-  'yarn add -D react-native-version && ./node_modules/.bin/react-native-version  --never-increment-build && yarn remove react-native-version',
-  {
-    cwd: rootDirectory,
-  },
-);
+execSync('npx react-native-version --never-increment-build', {
+  cwd: rootDirectory,
+});
 
 console.log('\n📝 Committing project...');
 execSync(

--- a/setup/index.js
+++ b/setup/index.js
@@ -37,14 +37,6 @@ deleteFile('../.gitattributes'); // not sure why this is here?
 execSync('rm -rf setup', { cwd: rootDirectory });
 execSync('rm -rf .git', { cwd: rootDirectory }); // blow away old repo if there
 
-console.log('\n📱 Setting initial version @0.0.1 ...');
-execSync(
-  'yarn add -D react-native-version && ./node_modules/.bin/react-native-version  --never-increment-build && yarn remove react-native-version',
-  {
-    cwd: rootDirectory,
-  },
-);
-
 console.log('\n📝 Committing project...');
 execSync(
   'rm -rf .git && git init && git add . && git commit -m "Initialize new React Native project."',


### PR DESCRIPTION
## Overview / Description
Sets initial version of generated projects to `0.0.1`

## Changes
- Update *setup* script to run `react-native-version` to modify the version code for iOS + Android so *fastlane* auto increment feature will work without manual changes in native code to set initial version.
- Remove step to delete `.babelrc`, newer versions of RN projects generate a `babel.config.js` instead.

## Screenshots
![2019-02-26 12 35 10](https://user-images.githubusercontent.com/7504299/53444879-2514bc80-39c4-11e9-84b7-d331473eb8c1.gif)

## Checklist
- [ ] Automated tests
- [x] Creating a new project still works
- [ ] Added docs
- [x] PR title follows conventional changelog style. examples - "chore(dependencies): upgrade RN to 0.58", "fix(storybook) add missing stories for built-in components", "feat(workflow): auto-commit project after creating" 

Fixes #15 
