### PR TITLE
fix(android): re-order imports to fix issue on android

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,10 @@
 // import ApolloClient, { InMemoryCache } from 'apollo-boost';
 import React, { Component } from 'react';
 import SplashScreen from 'react-native-splash-screen';
-import Storybook from '../storybook';
-import './config/reactotron';
 import { createRootNav } from './navigation/RootNav';
+
+import './config/reactotron';
+import Storybook from '../storybook';
 
 interface State {
   removeWhenYouveAddedStateManagement?: true;


### PR DESCRIPTION
## Overview / Description
When a new project when generated the Android project would run but throw an odd error without a lot of detail (See #48).

## Changes
- Re-order imports so storybook is imported after reactotron config 

## Screenshots
![screenshot 2019-02-26 14 31 24](https://user-images.githubusercontent.com/7504299/53451242-34e7cd00-39d3-11e9-9dc4-cee0809b9759.png)


## Checklist
- [ ] Automated tests
- [x] Creating a new project still works
- [ ] Added docs
- [x] PR title follows conventional changelog style. examples - "chore(dependencies): upgrade RN to 0.58", "fix(storybook) add missing stories for built-in components", "feat(workflow): auto-commit project after creating" 

Fixes #48 
