### PR TITLE
chore(workflow): remove "conventional changelog" checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,5 @@ Overview / Description
 - [ ] Automated tests
 - [ ] Creating a new project still works
 - [ ] Added docs
-- [ ] PR title follows conventional changelog style. examples - "chore(dependencies): upgrade RN to 0.58", "fix(storybook) add missing stories for built-in components", "feat(workflow): auto-commit project after creating" 
 
 Fixes #xx


### PR DESCRIPTION
We have a GH Check that does this for us now.