### PR TITLE
Use correct value for determining if Flipper is activated and fix Flipper version

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -25,4 +25,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.54.0
+FLIPPER_VERSION=0.75.1

--- a/template/ios/HelloWorld/AppDelegate.m
+++ b/template/ios/HelloWorld/AppDelegate.m
@@ -5,7 +5,7 @@
 #import <React/RCTRootView.h>
 #import "RNBootSplash.h"
 
-#ifdef DEBUG
+#ifdef FB_SONARKIT_ENABLED
 #import <FlipperKit/FlipperClient.h>
 #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
 #import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
@@ -28,7 +28,7 @@ static void InitializeFlipper(UIApplication *application) {
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-#ifdef DEBUG
+#ifdef FB_SONARKIT_ENABLED
   InitializeFlipper(application);
 #endif
 

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -17,7 +17,7 @@ target 'HelloWorld' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
-  use_flipper!
+  use_flipper!({ 'Flipper' => '0.75.1' })
   post_install do |installer|
     flipper_post_install(installer)
   end


### PR DESCRIPTION
## Description

While trying to build the template, ran into an issue with disabling Flipper not working correctly. It looks like this change was missed in the RN upgrade, so adding it here. 

![image](https://user-images.githubusercontent.com/17347720/108003948-32f4eb00-6fa9-11eb-89b0-ff2f71437e40.png)

Also, I was running into issues on my machine building due to [this Flipper issue](https://github.com/facebook/react-native/issues/30836). I was able to build after making the changes suggested [here](https://fbflipper.com/docs/getting-started/react-native/#using-the-latest-flipper-sdk), so adding them to the template.

## Screenshots

![Screen Shot 2021-02-16 at 8 15 42 AM](https://user-images.githubusercontent.com/17347720/108090674-ba853d00-702f-11eb-8026-6b8c451478ad.png)
![Screen Shot 2021-02-16 at 8 18 35 AM](https://user-images.githubusercontent.com/17347720/108090678-bbb66a00-702f-11eb-8991-189a1c7040d7.png)
![Screen Shot 2021-02-16 at 8 18 45 AM](https://user-images.githubusercontent.com/17347720/108090680-bc4f0080-702f-11eb-851f-49d54898bcdf.png)
